### PR TITLE
feat: multi-proposal stage linking and matching improvements

### DIFF
--- a/packages/nextjs/app/admin/matching/_components/MatchingResultsTable.tsx
+++ b/packages/nextjs/app/admin/matching/_components/MatchingResultsTable.tsx
@@ -72,7 +72,7 @@ function ResultDetailModal({ result, onClose }: { result: MatchingResultRow; onC
               href={result.source_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="link link-primary text-sm mt-1 block break-all"
+              className="text-sm mt-1 block break-all text-sky-400 hover:text-sky-300 underline"
             >
               {result.source_url}
             </a>
@@ -111,7 +111,7 @@ function ResultDetailModal({ result, onClose }: { result: MatchingResultRow; onC
               href={result.matched_forum_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="link link-secondary text-sm break-all"
+              className="text-sm break-all text-sky-400 hover:text-sky-300 underline"
             >
               {result.matched_forum_url}
             </a>

--- a/packages/nextjs/app/admin/matching/_components/PendingStagesTable.tsx
+++ b/packages/nextjs/app/admin/matching/_components/PendingStagesTable.tsx
@@ -2,6 +2,22 @@
 
 import { PendingStage, typeBadgeColor } from "./types";
 
+function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.round((now - then) / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMonth = Math.round(diffDay / 30);
+  return `${diffMonth}mo ago`;
+}
+
 interface Props {
   stages: PendingStage[];
   runningJobs: Map<string, string>;
@@ -27,6 +43,7 @@ export function PendingStagesTable({ stages, runningJobs, onMatch }: Props) {
               <th>Type</th>
               <th>Title</th>
               <th>Author</th>
+              <th>Last Activity</th>
               <th>URL</th>
               <th>Action</th>
             </tr>
@@ -45,6 +62,12 @@ export function PendingStagesTable({ stages, runningJobs, onMatch }: Props) {
                     {stage.title ?? "—"}
                   </td>
                   <td className="max-w-[120px] truncate">{stage.authorName ?? "—"}</td>
+                  <td
+                    className="text-xs text-base-content/70 whitespace-nowrap"
+                    title={stage.lastActivity ? new Date(stage.lastActivity).toLocaleString() : ""}
+                  >
+                    {relativeTime(stage.lastActivity)}
+                  </td>
                   <td>
                     {stage.url ? (
                       <a

--- a/packages/nextjs/app/admin/matching/_components/types.ts
+++ b/packages/nextjs/app/admin/matching/_components/types.ts
@@ -4,6 +4,7 @@ export interface PendingStage {
   title: string | null;
   authorName: string | null;
   url: string | null;
+  lastActivity: string | null;
 }
 
 export type SourceType = "snapshot" | "tally";

--- a/packages/nextjs/app/api/admin/matching/pending/route.ts
+++ b/packages/nextjs/app/api/admin/matching/pending/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
         title: r.snapshotStage.title,
         authorName: r.snapshotStage.author_name,
         url: r.snapshotStage.url,
+        lastActivity: r.snapshotStage.voting_end?.toISOString() ?? null,
       })),
       ...tallyRows.map(r => ({
         sourceType: "tally" as const,
@@ -24,8 +25,16 @@ export async function GET() {
         title: r.tallyStage.title,
         authorName: r.tallyStage.author_name,
         url: r.tallyStage.url,
+        lastActivity: r.tallyStage.last_activity?.toISOString() ?? null,
       })),
     ];
+
+    // Sort the combined list by last activity (most recent first)
+    pending.sort((a, b) => {
+      const dateA = a.lastActivity ? new Date(a.lastActivity).getTime() : 0;
+      const dateB = b.lastActivity ? new Date(b.lastActivity).getTime() : 0;
+      return dateB - dateA;
+    });
 
     return NextResponse.json(pending);
   } catch (error) {

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -26,10 +26,9 @@ export const forumStage = pgTable("forum_stage", {
   updated_at: timestamp("updated_at").defaultNow(),
 });
 
-// Snapshot stage (nullable foreign key; linked later)
+// Snapshot stage
 export const snapshotStage = pgTable("snapshot_stage", {
   id: uuid("id").defaultRandom().primaryKey(),
-  proposal_id: uuid("proposal_id").references(() => proposals.id, { onDelete: "set null" }),
 
   snapshot_id: text("snapshot_id").unique(),
   title: text("title"),
@@ -45,10 +44,9 @@ export const snapshotStage = pgTable("snapshot_stage", {
   updated_at: timestamp("updated_at").defaultNow(),
 });
 
-// Tally stage (nullable foreign key; linked later)
+// Tally stage
 export const tallyStage = pgTable("tally_stage", {
   id: uuid("id").defaultRandom().primaryKey(),
-  proposal_id: uuid("proposal_id").references(() => proposals.id, { onDelete: "set null" }),
 
   tally_proposal_id: text("tally_proposal_id").unique(),
   title: text("title"),
@@ -99,27 +97,11 @@ export const users = pgTable("user", {
 
 export const proposalsRelations = relations(proposals, ({ many }) => ({
   forumStages: many(forumStage),
-  snapshotStages: many(snapshotStage),
-  tallyStages: many(tallyStage),
 }));
 
 export const forumStageRelations = relations(forumStage, ({ one }) => ({
   proposal: one(proposals, {
     fields: [forumStage.proposal_id],
-    references: [proposals.id],
-  }),
-}));
-
-export const snapshotStageRelations = relations(snapshotStage, ({ one }) => ({
-  proposal: one(proposals, {
-    fields: [snapshotStage.proposal_id],
-    references: [proposals.id],
-  }),
-}));
-
-export const tallyStageRelations = relations(tallyStage, ({ one }) => ({
-  proposal: one(proposals, {
-    fields: [tallyStage.proposal_id],
     references: [proposals.id],
   }),
 }));

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -87,7 +87,7 @@ export const matchingResult = pgTable(
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   },
-  table => [unique().on(table.source_type, table.source_stage_id)],
+  table => [unique().on(table.source_type, table.source_stage_id, table.proposal_id)],
 );
 
 // Users table for admin management

--- a/packages/nextjs/services/database/repositories/matching.ts
+++ b/packages/nextjs/services/database/repositories/matching.ts
@@ -34,7 +34,8 @@ export async function getUnprocessedSnapshotStages() {
       matchingResult,
       and(eq(matchingResult.source_type, "snapshot"), eq(matchingResult.source_stage_id, snapshotStage.id)),
     )
-    .where(sql`${matchingResult.id} IS NULL`);
+    .where(sql`${matchingResult.id} IS NULL`)
+    .orderBy(desc(snapshotStage.voting_end));
 }
 
 export async function getUnprocessedTallyStages() {
@@ -45,7 +46,8 @@ export async function getUnprocessedTallyStages() {
       matchingResult,
       and(eq(matchingResult.source_type, "tally"), eq(matchingResult.source_stage_id, tallyStage.id)),
     )
-    .where(sql`${matchingResult.id} IS NULL`);
+    .where(sql`${matchingResult.id} IS NULL`)
+    .orderBy(desc(tallyStage.last_activity));
 }
 
 export async function getMatchingResultsBySourceType(sourceType: "snapshot" | "tally") {

--- a/packages/nextjs/services/database/repositories/matching.ts
+++ b/packages/nextjs/services/database/repositories/matching.ts
@@ -9,7 +9,7 @@ export async function upsertMatchingResult(data: Omit<MatchingResultInsert, "id"
     .insert(matchingResult)
     .values(data)
     .onConflictDoUpdate({
-      target: [matchingResult.source_type, matchingResult.source_stage_id],
+      target: [matchingResult.source_type, matchingResult.source_stage_id, matchingResult.proposal_id],
       set: {
         proposal_id: data.proposal_id ?? null,
         status: data.status,

--- a/packages/nextjs/services/database/repositories/proposals.ts
+++ b/packages/nextjs/services/database/repositories/proposals.ts
@@ -41,39 +41,29 @@ function formatDisplayStatus(status: string | null): string | null {
 }
 
 export async function getDashboardProposals() {
-  // 1. Fetch proposals with forum stages (forum still uses direct FK)
-  const proposalRows = await db.query.proposals.findMany({
-    with: {
-      forumStages: {
-        orderBy: (forumStage, { desc }) => [desc(forumStage.last_message_at)],
-        limit: 1,
+  const [proposalRows, snapshotLinks, tallyLinks] = await Promise.all([
+    db.query.proposals.findMany({
+      with: {
+        forumStages: {
+          orderBy: (forumStage, { desc }) => [desc(forumStage.last_message_at)],
+          limit: 1,
+        },
       },
-    },
-  });
+    }),
+    db
+      .select({ proposalId: matchingResult.proposal_id, stage: snapshotStage })
+      .from(matchingResult)
+      .innerJoin(snapshotStage, eq(matchingResult.source_stage_id, snapshotStage.id))
+      .where(and(eq(matchingResult.source_type, "snapshot"), eq(matchingResult.status, "matched")))
+      .orderBy(desc(snapshotStage.voting_end)),
+    db
+      .select({ proposalId: matchingResult.proposal_id, stage: tallyStage })
+      .from(matchingResult)
+      .innerJoin(tallyStage, eq(matchingResult.source_stage_id, tallyStage.id))
+      .where(and(eq(matchingResult.source_type, "tally"), eq(matchingResult.status, "matched")))
+      .orderBy(desc(tallyStage.last_activity)),
+  ]);
 
-  // 2. Fetch matched snapshot stages via matching_result
-  const snapshotLinks = await db
-    .select({
-      proposalId: matchingResult.proposal_id,
-      stage: snapshotStage,
-    })
-    .from(matchingResult)
-    .innerJoin(snapshotStage, eq(matchingResult.source_stage_id, snapshotStage.id))
-    .where(and(eq(matchingResult.source_type, "snapshot"), eq(matchingResult.status, "matched")))
-    .orderBy(desc(snapshotStage.voting_end));
-
-  // 3. Fetch matched tally stages via matching_result
-  const tallyLinks = await db
-    .select({
-      proposalId: matchingResult.proposal_id,
-      stage: tallyStage,
-    })
-    .from(matchingResult)
-    .innerJoin(tallyStage, eq(matchingResult.source_stage_id, tallyStage.id))
-    .where(and(eq(matchingResult.source_type, "tally"), eq(matchingResult.status, "matched")))
-    .orderBy(desc(tallyStage.last_activity));
-
-  // 4. Group stages by proposal_id
   const snapshotsByProposal = new Map<string, (typeof snapshotLinks)[number]["stage"][]>();
   for (const link of snapshotLinks) {
     if (!link.proposalId) continue;
@@ -90,7 +80,8 @@ export async function getDashboardProposals() {
     tallyByProposal.set(link.proposalId, arr);
   }
 
-  // 5. Assemble results (same shape as before)
+  const sortKeyByProposal = new Map<string, number>();
+
   const assembled = proposalRows.map(row => {
     const forum = row.forumStages[0] ?? null;
     const snapshotStages = snapshotsByProposal.get(row.id) ?? [];
@@ -102,7 +93,6 @@ export async function getDashboardProposals() {
     const snapshotOptions = snapshot?.options as SnapshotOptions | null;
     const tallyOptions = tally?.options as TallyOptions | null;
 
-    // Map older snapshot stages (skip index 0, which is the latest)
     const snapshotHistory: VotingStageItem[] = snapshotStages.slice(1).map(s => {
       const opts = s.options as SnapshotOptions | null;
       const status = resolveSnapshotResult(s.status ?? null, opts);
@@ -116,7 +106,6 @@ export async function getDashboardProposals() {
       };
     });
 
-    // Map older tally stages (skip index 0, which is the latest)
     const tallyHistory: VotingStageItem[] = tallyStages.slice(1).map(t => {
       const opts = t.options as TallyOptions | null;
       const status = mapTallyStatus(t.status ?? null, t.substatus ?? null);
@@ -132,6 +121,7 @@ export async function getDashboardProposals() {
     });
 
     const lastActivityDate = tally?.last_activity ?? snapshot?.voting_end ?? forum?.last_message_at ?? null;
+    sortKeyByProposal.set(row.id, lastActivityDate?.getTime() ?? 0);
 
     return {
       id: row.id,
@@ -155,21 +145,7 @@ export async function getDashboardProposals() {
     };
   });
 
-  // Sort by most relevant stage date: tally > snapshot > forum
-  assembled.sort((a, b) => {
-    const getDate = (item: (typeof assembled)[number]) => {
-      const tallyStages = tallyByProposal.get(item.id);
-      const snapStages = snapshotsByProposal.get(item.id);
-      const forumRow = proposalRows.find(p => p.id === item.id);
-      return (
-        tallyStages?.[0]?.last_activity ??
-        snapStages?.[0]?.voting_end ??
-        forumRow?.forumStages[0]?.last_message_at ??
-        null
-      );
-    };
-    return (getDate(b)?.getTime() ?? 0) - (getDate(a)?.getTime() ?? 0);
-  });
+  assembled.sort((a, b) => (sortKeyByProposal.get(b.id) ?? 0) - (sortKeyByProposal.get(a.id) ?? 0));
 
   return assembled;
 }

--- a/packages/nextjs/services/database/repositories/proposals.ts
+++ b/packages/nextjs/services/database/repositories/proposals.ts
@@ -1,5 +1,5 @@
-import { proposals } from "../config/schema";
-import { InferInsertModel } from "drizzle-orm";
+import { matchingResult, proposals, snapshotStage, tallyStage } from "../config/schema";
+import { InferInsertModel, and, desc, eq } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 import {
   type SnapshotOptions,
@@ -41,41 +41,69 @@ function formatDisplayStatus(status: string | null): string | null {
 }
 
 export async function getDashboardProposals() {
-  const rows = await db.query.proposals.findMany({
+  // 1. Fetch proposals with forum stages (forum still uses direct FK)
+  const proposalRows = await db.query.proposals.findMany({
     with: {
       forumStages: {
         orderBy: (forumStage, { desc }) => [desc(forumStage.last_message_at)],
         limit: 1,
       },
-      snapshotStages: {
-        orderBy: (snapshotStage, { desc }) => [desc(snapshotStage.voting_end)],
-      },
-      tallyStages: {
-        orderBy: (tallyStage, { desc }) => [desc(tallyStage.last_activity)],
-      },
     },
-    orderBy: (proposals, { desc }) => [desc(proposals.updated_at)],
   });
 
-  // Sort by most relevant stage date: tally > snapshot > forum
-  rows.sort((a, b) => {
-    const dateA =
-      a.tallyStages[0]?.last_activity ?? a.snapshotStages[0]?.voting_end ?? a.forumStages[0]?.last_message_at;
-    const dateB =
-      b.tallyStages[0]?.last_activity ?? b.snapshotStages[0]?.voting_end ?? b.forumStages[0]?.last_message_at;
-    return (dateB?.getTime() ?? 0) - (dateA?.getTime() ?? 0);
-  });
+  // 2. Fetch matched snapshot stages via matching_result
+  const snapshotLinks = await db
+    .select({
+      proposalId: matchingResult.proposal_id,
+      stage: snapshotStage,
+    })
+    .from(matchingResult)
+    .innerJoin(snapshotStage, eq(matchingResult.source_stage_id, snapshotStage.id))
+    .where(and(eq(matchingResult.source_type, "snapshot"), eq(matchingResult.status, "matched")))
+    .orderBy(desc(snapshotStage.voting_end));
 
-  return rows.map(row => {
+  // 3. Fetch matched tally stages via matching_result
+  const tallyLinks = await db
+    .select({
+      proposalId: matchingResult.proposal_id,
+      stage: tallyStage,
+    })
+    .from(matchingResult)
+    .innerJoin(tallyStage, eq(matchingResult.source_stage_id, tallyStage.id))
+    .where(and(eq(matchingResult.source_type, "tally"), eq(matchingResult.status, "matched")))
+    .orderBy(desc(tallyStage.last_activity));
+
+  // 4. Group stages by proposal_id
+  const snapshotsByProposal = new Map<string, (typeof snapshotLinks)[number]["stage"][]>();
+  for (const link of snapshotLinks) {
+    if (!link.proposalId) continue;
+    const arr = snapshotsByProposal.get(link.proposalId) ?? [];
+    arr.push(link.stage);
+    snapshotsByProposal.set(link.proposalId, arr);
+  }
+
+  const tallyByProposal = new Map<string, (typeof tallyLinks)[number]["stage"][]>();
+  for (const link of tallyLinks) {
+    if (!link.proposalId) continue;
+    const arr = tallyByProposal.get(link.proposalId) ?? [];
+    arr.push(link.stage);
+    tallyByProposal.set(link.proposalId, arr);
+  }
+
+  // 5. Assemble results (same shape as before)
+  const assembled = proposalRows.map(row => {
     const forum = row.forumStages[0] ?? null;
-    const snapshot = row.snapshotStages[0] ?? null;
-    const tally = row.tallyStages[0] ?? null;
+    const snapshotStages = snapshotsByProposal.get(row.id) ?? [];
+    const tallyStages = tallyByProposal.get(row.id) ?? [];
+
+    const snapshot = snapshotStages[0] ?? null;
+    const tally = tallyStages[0] ?? null;
 
     const snapshotOptions = snapshot?.options as SnapshotOptions | null;
     const tallyOptions = tally?.options as TallyOptions | null;
 
     // Map older snapshot stages (skip index 0, which is the latest)
-    const snapshotHistory: VotingStageItem[] = row.snapshotStages.slice(1).map(s => {
+    const snapshotHistory: VotingStageItem[] = snapshotStages.slice(1).map(s => {
       const opts = s.options as SnapshotOptions | null;
       const status = resolveSnapshotResult(s.status ?? null, opts);
       return {
@@ -89,7 +117,7 @@ export async function getDashboardProposals() {
     });
 
     // Map older tally stages (skip index 0, which is the latest)
-    const tallyHistory: VotingStageItem[] = row.tallyStages.slice(1).map(t => {
+    const tallyHistory: VotingStageItem[] = tallyStages.slice(1).map(t => {
       const opts = t.options as TallyOptions | null;
       const status = mapTallyStatus(t.status ?? null, t.substatus ?? null);
       return {
@@ -126,6 +154,24 @@ export async function getDashboardProposals() {
       tallyHistory,
     };
   });
+
+  // Sort by most relevant stage date: tally > snapshot > forum
+  assembled.sort((a, b) => {
+    const getDate = (item: (typeof assembled)[number]) => {
+      const tallyStages = tallyByProposal.get(item.id);
+      const snapStages = snapshotsByProposal.get(item.id);
+      const forumRow = proposalRows.find(p => p.id === item.id);
+      return (
+        tallyStages?.[0]?.last_activity ??
+        snapStages?.[0]?.voting_end ??
+        forumRow?.forumStages[0]?.last_message_at ??
+        null
+      );
+    };
+    return (getDate(b)?.getTime() ?? 0) - (getDate(a)?.getTime() ?? 0);
+  });
+
+  return assembled;
 }
 
 export type DashboardProposal = Awaited<ReturnType<typeof getDashboardProposals>>[number];

--- a/packages/nextjs/services/database/repositories/snapshot.ts
+++ b/packages/nextjs/services/database/repositories/snapshot.ts
@@ -1,6 +1,5 @@
 import { snapshotStage } from "../config/schema";
-import { InferInsertModel } from "drizzle-orm";
-import { eq, isNull } from "drizzle-orm";
+import { InferInsertModel, eq } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 
 type SnapshotStageData = InferInsertModel<typeof snapshotStage>;
@@ -34,12 +33,6 @@ export async function updateSnapshotStageBySnapshotId(snapshotId: string, update
   return updated;
 }
 
-export async function getAllSnapshotStagesWithoutProposal() {
-  return await db.query.snapshotStage.findMany({
-    where: isNull(snapshotStage.proposal_id),
-  });
-}
-
 export async function getAllSnapshotStages() {
   return await db.query.snapshotStage.findMany();
 }
@@ -54,13 +47,4 @@ export async function getSnapshotStageBySnapshotId(snapshotId: string) {
   return await db.query.snapshotStage.findFirst({
     where: eq(snapshotStage.snapshot_id, snapshotId),
   });
-}
-
-export async function updateSnapshotProposalId(snapshotStageId: string, proposalId: string) {
-  const [updated] = await db
-    .update(snapshotStage)
-    .set({ proposal_id: proposalId, updated_at: new Date() })
-    .where(eq(snapshotStage.id, snapshotStageId))
-    .returning();
-  return updated;
 }

--- a/packages/nextjs/services/database/repositories/tally.ts
+++ b/packages/nextjs/services/database/repositories/tally.ts
@@ -1,6 +1,5 @@
 import { tallyStage } from "../config/schema";
-import { InferInsertModel } from "drizzle-orm";
-import { eq, isNull } from "drizzle-orm";
+import { InferInsertModel, eq } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 
 type TallyStageData = InferInsertModel<typeof tallyStage>;
@@ -38,12 +37,6 @@ export async function updateTallyStageByTallyProposalId(tallyProposalId: string,
   return updated;
 }
 
-export async function getAllTallyStagesWithoutProposal() {
-  return await db.query.tallyStage.findMany({
-    where: isNull(tallyStage.proposal_id),
-  });
-}
-
 export async function getAllTallyStages() {
   return await db.query.tallyStage.findMany();
 }
@@ -52,15 +45,6 @@ export async function getTallyStageById(id: string) {
   return await db.query.tallyStage.findFirst({
     where: eq(tallyStage.id, id),
   });
-}
-
-export async function updateTallyProposalId(tallyStageId: string, proposalId: string) {
-  const [updated] = await db
-    .update(tallyStage)
-    .set({ proposal_id: proposalId, updated_at: new Date() })
-    .where(eq(tallyStage.id, tallyStageId))
-    .returning();
-  return updated;
 }
 
 export async function getTallyStageByOnchainId(onchainId: string) {

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -68,7 +68,6 @@ async function seed() {
     });
 
     await db.insert(snapshotStage).values({
-      proposal_id: proposal1.id,
       snapshot_id: "snap-001",
       title: proposal1.title,
       author_name: proposal1.author_name,
@@ -83,7 +82,6 @@ async function seed() {
     });
 
     await db.insert(tallyStage).values({
-      proposal_id: proposal1.id,
       tally_proposal_id: "tally-001",
       title: proposal1.title,
       author_name: proposal1.author_name,
@@ -109,7 +107,6 @@ async function seed() {
     });
 
     await db.insert(snapshotStage).values({
-      proposal_id: proposal2.id,
       snapshot_id: "snap-002",
       title: proposal2.title,
       author_name: proposal2.author_name,

--- a/packages/nextjs/services/matching/import-snapshot-matches-csv.ts
+++ b/packages/nextjs/services/matching/import-snapshot-matches-csv.ts
@@ -9,11 +9,7 @@
  */
 import { getForumStageByUrl } from "../database/repositories/forum";
 import { getUnprocessedSnapshotStages, upsertMatchingResult } from "../database/repositories/matching";
-import {
-  getAllSnapshotStages,
-  getSnapshotStageBySnapshotId,
-  updateSnapshotProposalId,
-} from "../database/repositories/snapshot";
+import { getAllSnapshotStages, getSnapshotStageBySnapshotId } from "../database/repositories/snapshot";
 import { ImportResult, decodeHtmlEntities, parseCsvLine, readFileContent } from "./csv-utils";
 import * as dotenv from "dotenv";
 import * as path from "path";
@@ -197,32 +193,10 @@ export async function importSnapshotMatchesFromCsv(): Promise<ImportResult> {
         continue;
       }
 
-      const proposalId = forum.proposal_id;
-
-      // Check if already linked to the same proposal
-      if (existingSnapshot.proposal_id === proposalId) {
-        result.alreadyLinked++;
-        await upsertMatchingResult({
-          source_type: "snapshot",
-          source_stage_id: existingSnapshot.id,
-          proposal_id: proposalId,
-          status: "matched",
-          method: isManualOverride ? "manual_override" : "csv_import",
-          confidence: !isManualOverride ? (llmData?.confidence_score ?? null) : null,
-          reasoning: !isManualOverride ? (llmData?.reasoning ?? null) : null,
-          source_title: row.snapshot_title || null,
-          source_url: row.snapshot_url || null,
-          matched_forum_url: forumUrl,
-        });
-        continue;
-      }
-
-      await updateSnapshotProposalId(existingSnapshot.id, proposalId);
-
       await upsertMatchingResult({
         source_type: "snapshot",
         source_stage_id: existingSnapshot.id,
-        proposal_id: proposalId,
+        proposal_id: forum.proposal_id,
         status: "matched",
         method: isManualOverride ? "manual_override" : "csv_import",
         confidence: !isManualOverride ? (llmData?.confidence_score ?? null) : null,
@@ -233,7 +207,7 @@ export async function importSnapshotMatchesFromCsv(): Promise<ImportResult> {
       });
 
       const manualNote = isManualOverride ? " [MANUAL]" : "";
-      console.log(`Updated: "${row.snapshot_title?.slice(0, 50)}..." -> ${proposalId}${manualNote}`);
+      console.log(`Updated: "${row.snapshot_title?.slice(0, 50)}..." -> ${forum.proposal_id}${manualNote}`);
       result.updated++;
     } catch (error) {
       const errorMessage = `Error processing "${row.snapshot_title}": ${error}`;

--- a/packages/nextjs/services/matching/import-snapshot-matches-csv.ts
+++ b/packages/nextjs/services/matching/import-snapshot-matches-csv.ts
@@ -9,7 +9,11 @@
  */
 import { getForumStageByUrl } from "../database/repositories/forum";
 import { getUnprocessedSnapshotStages, upsertMatchingResult } from "../database/repositories/matching";
-import { getSnapshotStageBySnapshotId, updateSnapshotProposalId } from "../database/repositories/snapshot";
+import {
+  getAllSnapshotStages,
+  getSnapshotStageBySnapshotId,
+  updateSnapshotProposalId,
+} from "../database/repositories/snapshot";
 import { ImportResult, decodeHtmlEntities, parseCsvLine, readFileContent } from "./csv-utils";
 import * as dotenv from "dotenv";
 import * as path from "path";
@@ -239,19 +243,28 @@ export async function importSnapshotMatchesFromCsv(): Promise<ImportResult> {
   }
 
   // Phase 2: LLM no-match entries (canonical_proposal_id === null in JSON, excluded from CSV)
+  const allSnapshotStagesForLookup = await getAllSnapshotStages();
+  const snapshotByTitle = new Map(allSnapshotStagesForLookup.map(s => [s.title?.trim() ?? "", s]));
+
   const llmNoMatchEntries = llmEntries.filter(entry => entry.canonical_proposal_id === null);
   for (const entry of llmNoMatchEntries) {
     try {
+      const stage = snapshotByTitle.get(entry.title?.trim() ?? "");
+      if (!stage) {
+        // Stage doesn't exist in DB — skip silently
+        continue;
+      }
+
       await upsertMatchingResult({
         source_type: "snapshot",
-        source_stage_id: entry.snapshot_id,
+        source_stage_id: stage.id,
         proposal_id: null,
         status: "no_match",
         method: "csv_import",
         confidence: entry.confidence_score ?? null,
         reasoning: entry.reasoning ?? null,
         source_title: entry.title || null,
-        source_url: null,
+        source_url: stage.url || null,
         matched_forum_url: null,
       });
       result.noMatch++;

--- a/packages/nextjs/services/matching/import-tally-matches-csv.ts
+++ b/packages/nextjs/services/matching/import-tally-matches-csv.ts
@@ -8,7 +8,7 @@
  */
 import { getForumStageByUrl } from "../database/repositories/forum";
 import { getUnprocessedTallyStages, upsertMatchingResult } from "../database/repositories/matching";
-import { getTallyStageByOnchainId, updateTallyProposalId } from "../database/repositories/tally";
+import { getAllTallyStages, getTallyStageByOnchainId, updateTallyProposalId } from "../database/repositories/tally";
 import { ImportResult, decodeHtmlEntities, parseCsvLine, readFileContent } from "./csv-utils";
 import * as dotenv from "dotenv";
 import * as path from "path";
@@ -238,19 +238,28 @@ export async function importTallyMatchesFromCsv(): Promise<ImportResult> {
   }
 
   // Phase 2: LLM no-match entries (canonical_proposal_id === null in JSON, excluded from CSV)
+  const allTallyStagesForLookup = await getAllTallyStages();
+  const tallyByTitle = new Map(allTallyStagesForLookup.map(s => [s.title?.trim() ?? "", s]));
+
   const llmNoMatchEntries = llmEntries.filter(entry => entry.canonical_proposal_id === null);
   for (const entry of llmNoMatchEntries) {
     try {
+      const stage = tallyByTitle.get(entry.title?.trim() ?? "");
+      if (!stage) {
+        // Stage doesn't exist in DB — skip silently
+        continue;
+      }
+
       await upsertMatchingResult({
         source_type: "tally",
-        source_stage_id: entry.tally_id,
+        source_stage_id: stage.id,
         proposal_id: null,
         status: "no_match",
         method: "csv_import",
         confidence: entry.confidence_score ?? null,
         reasoning: entry.reasoning ?? null,
         source_title: entry.title || null,
-        source_url: null,
+        source_url: stage.url || null,
         matched_forum_url: null,
       });
       result.noMatch++;

--- a/packages/nextjs/services/matching/import-tally-matches-csv.ts
+++ b/packages/nextjs/services/matching/import-tally-matches-csv.ts
@@ -8,7 +8,7 @@
  */
 import { getForumStageByUrl } from "../database/repositories/forum";
 import { getUnprocessedTallyStages, upsertMatchingResult } from "../database/repositories/matching";
-import { getAllTallyStages, getTallyStageByOnchainId, updateTallyProposalId } from "../database/repositories/tally";
+import { getAllTallyStages, getTallyStageByOnchainId } from "../database/repositories/tally";
 import { ImportResult, decodeHtmlEntities, parseCsvLine, readFileContent } from "./csv-utils";
 import * as dotenv from "dotenv";
 import * as path from "path";
@@ -192,32 +192,10 @@ export async function importTallyMatchesFromCsv(): Promise<ImportResult> {
         continue;
       }
 
-      const proposalId = forum.proposal_id;
-
-      // Check if already linked to the same proposal
-      if (existingTally.proposal_id === proposalId) {
-        result.alreadyLinked++;
-        await upsertMatchingResult({
-          source_type: "tally",
-          source_stage_id: existingTally.id,
-          proposal_id: proposalId,
-          status: "matched",
-          method: isManualOverride ? "manual_override" : "csv_import",
-          confidence: !isManualOverride ? (llmData?.confidence_score ?? null) : null,
-          reasoning: !isManualOverride ? (llmData?.reasoning ?? null) : null,
-          source_title: row.tally_title || null,
-          source_url: row.tally_url || null,
-          matched_forum_url: forumUrl,
-        });
-        continue;
-      }
-
-      await updateTallyProposalId(existingTally.id, proposalId);
-
       await upsertMatchingResult({
         source_type: "tally",
         source_stage_id: existingTally.id,
-        proposal_id: proposalId,
+        proposal_id: forum.proposal_id,
         status: "matched",
         method: isManualOverride ? "manual_override" : "csv_import",
         confidence: !isManualOverride ? (llmData?.confidence_score ?? null) : null,
@@ -228,7 +206,7 @@ export async function importTallyMatchesFromCsv(): Promise<ImportResult> {
       });
 
       const manualNote = isManualOverride ? " [MANUAL]" : "";
-      console.log(`Updated: "${row.tally_title?.slice(0, 50)}..." -> ${proposalId}${manualNote}`);
+      console.log(`Updated: "${row.tally_title?.slice(0, 50)}..." -> ${forum.proposal_id}${manualNote}`);
       result.updated++;
     } catch (error) {
       const errorMessage = `Error processing "${row.tally_title}": ${error}`;

--- a/packages/nextjs/services/matching/llm-matching.ts
+++ b/packages/nextjs/services/matching/llm-matching.ts
@@ -203,7 +203,12 @@ export async function matchStage(
 
   console.log(`    → MATCHED ${validMatches.length} proposal(s)`);
 
-  // Create a matching_result row for each match
+  // TODO: gate status on confidence_score. Every validated match is
+  // currently written as "matched" regardless of score, so low-confidence or
+  // hallucinated bundled matches land directly on the homepage. Proposed:
+  // introduce MIN_MATCH_CONFIDENCE and demote below-threshold matches to
+  // status: "pending_review" (which the dashboard query already filters out).
+  // confidence is already stored on the row — just need to act on it.
   const primaryMatch = validMatches.reduce((best, m) => (m.confidence_score > best.confidence_score ? m : best));
 
   for (const match of validMatches) {

--- a/packages/nextjs/services/matching/llm-matching.ts
+++ b/packages/nextjs/services/matching/llm-matching.ts
@@ -3,12 +3,18 @@ import { getAllProposals } from "../database/repositories/proposals";
 import { getSnapshotStageById, updateSnapshotProposalId } from "../database/repositories/snapshot";
 import { getTallyStageById, updateTallyProposalId } from "../database/repositories/tally";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { db } from "~~/services/database/config/postgresClient";
 
-interface LlmMatchResult {
-  proposal_id: string | null;
-  confidence: string; // "high" | "medium" | "low" | "none"
+interface LlmMatch {
+  proposal_id: string;
+  confidence: string; // "high" | "medium" | "low"
   confidence_score: number; // 0-100
   reasoning: string;
+}
+
+interface LlmMatchResult {
+  matches: LlmMatch[];
+  reasoning: string; // Overall reasoning when no matches found
 }
 
 interface StageInfo {
@@ -26,7 +32,7 @@ function buildMatchingPrompt(
     .map(p => `- ID: ${p.id} | Title: ${p.title} | Author: ${p.author_name ?? "Unknown"}`)
     .join("\n");
 
-  return `You are matching an on-chain governance stage (from Snapshot or Tally) to its canonical forum proposal.
+  return `You are matching an on-chain governance stage (from Snapshot or Tally) to canonical forum proposals.
 
 ## Source Stage to Match
 - Title: ${stage.title ?? "Unknown"}
@@ -37,22 +43,34 @@ function buildMatchingPrompt(
 ${candidateList}
 
 ## Instructions
-1. Find the canonical proposal that this stage belongs to, based on title similarity, author, and context.
+1. Find the canonical proposal(s) that this stage belongs to, based on title similarity, author, and context.
 2. Many proposals go through multiple governance stages (forum → snapshot → tally), so titles may differ slightly.
 3. Common patterns: AIP prefixes may be added/removed, markdown formatting (#) in titles, slight rewording.
-4. Some stages will NOT match any proposal. These include:
+4. **IMPORTANT: Some stages are BUNDLED VOTES** that combine multiple proposals into a single on-chain transaction. In this case, return ALL matching proposals. Look for clues like:
+   - Titles listing multiple actions (e.g., "Remove Cost Cap, Update Executors, Disable Bridge")
+   - Titles mentioning "bundled" or combining multiple AIPs
+5. Some stages will NOT match any proposal. These include:
    - Security Council elections and member changes
    - STIP/LTIPP individual grant distributions (unless there's a matching umbrella proposal)
    - Operational/constitutional votes that predate the forum tracking
    - Proposals from other DAOs or test proposals
 
 Return a JSON object with these fields:
-- "proposal_id": the UUID of the matched canonical proposal, or null if no match
-- "confidence": "high", "medium", "low", or "none"
-- "confidence_score": integer 0-100
-- "reasoning": brief explanation of your matching decision
+- "matches": an array of matched proposals (can be empty, one, or multiple). Each match should have:
+  - "proposal_id": the UUID of the matched canonical proposal
+  - "confidence": "high", "medium", or "low"
+  - "confidence_score": integer 0-100
+  - "reasoning": brief explanation for this specific match
+- "reasoning": overall explanation (used when matches is empty to explain why)
 
-If no proposal matches, set proposal_id to null, confidence to "none", confidence_score to 0, and explain why in reasoning.`;
+Example for a single match:
+{"matches": [{"proposal_id": "abc-123", "confidence": "high", "confidence_score": 95, "reasoning": "Title matches exactly"}], "reasoning": ""}
+
+Example for a bundled vote matching multiple proposals:
+{"matches": [{"proposal_id": "abc-123", "confidence": "high", "confidence_score": 90, "reasoning": "Matches 'Remove Cost Cap'"}, {"proposal_id": "def-456", "confidence": "high", "confidence_score": 90, "reasoning": "Matches 'Update Executors'"}], "reasoning": ""}
+
+Example for no match:
+{"matches": [], "reasoning": "This is a Security Council election with no corresponding forum proposal"}`;
 }
 
 async function callGemini(prompt: string): Promise<LlmMatchResult> {
@@ -73,13 +91,38 @@ async function callGemini(prompt: string): Promise<LlmMatchResult> {
   const raw = JSON.parse(text);
   const parsed = (Array.isArray(raw) ? raw[0] : raw) as LlmMatchResult;
 
-  // Validate required fields
-  if (typeof parsed.confidence_score !== "number" || typeof parsed.reasoning !== "string") {
-    throw new Error(`Invalid LLM response structure: ${text}`);
+  // Normalize: handle old single-match format gracefully
+  if (!Array.isArray(parsed.matches)) {
+    // Old format: { proposal_id, confidence, confidence_score, reasoning }
+    const legacy = raw as {
+      proposal_id: string | null;
+      confidence_score: number;
+      reasoning: string;
+      confidence: string;
+    };
+    if (legacy.proposal_id) {
+      parsed.matches = [
+        {
+          proposal_id: legacy.proposal_id,
+          confidence: legacy.confidence ?? "medium",
+          confidence_score: Math.max(0, Math.min(100, Math.round(legacy.confidence_score))),
+          reasoning: legacy.reasoning ?? "",
+        },
+      ];
+      parsed.reasoning = "";
+    } else {
+      parsed.matches = [];
+      parsed.reasoning = legacy.reasoning ?? "";
+    }
   }
 
-  // Normalize confidence_score to 0-100 range
-  parsed.confidence_score = Math.max(0, Math.min(100, Math.round(parsed.confidence_score)));
+  // Validate and normalize scores
+  for (const match of parsed.matches) {
+    if (typeof match.confidence_score !== "number" || typeof match.reasoning !== "string") {
+      throw new Error(`Invalid LLM match structure: ${text}`);
+    }
+    match.confidence_score = Math.max(0, Math.min(100, Math.round(match.confidence_score)));
+  }
 
   return parsed;
 }
@@ -87,7 +130,7 @@ async function callGemini(prompt: string): Promise<LlmMatchResult> {
 export async function matchStage(
   sourceType: "tally" | "snapshot",
   stageId: string,
-): Promise<{ status: string; proposalId: string | null }> {
+): Promise<{ status: string; proposalId: string | null; matchCount: number }> {
   // Load the stage info
   let stage: StageInfo | undefined;
 
@@ -99,63 +142,83 @@ export async function matchStage(
 
   if (!stage) {
     console.log(`  Stage ${stageId} not found in ${sourceType}_stage table`);
-    return { status: "not_found", proposalId: null };
+    return { status: "not_found", proposalId: null, matchCount: 0 };
   }
 
   console.log(`  Matching: "${stage.title}" (${stageId})`);
 
-  // Load all canonical proposals
+  // Load all canonical proposals + forum URLs
   const allProposals = await getAllProposals();
   if (allProposals.length === 0) {
     throw new Error("No proposals found in database. Cannot match.");
   }
 
+  // Build proposalId → forumUrl map for matched_forum_url
+  const forumRows = await db.query.forumStage.findMany({
+    columns: { proposal_id: true, url: true },
+  });
+  const forumUrlByProposal = new Map<string, string | null>(
+    forumRows.filter(f => f.proposal_id).map(f => [f.proposal_id!, f.url ?? null]),
+  );
+
   // Build prompt and call LLM
   const prompt = buildMatchingPrompt(stage, allProposals);
   const llmResult = await callGemini(prompt);
 
-  console.log(
-    `    → ${llmResult.proposal_id ? "MATCHED" : "NO MATCH"} (score: ${llmResult.confidence_score}, confidence: ${llmResult.confidence})`,
-  );
-  console.log(`    → ${llmResult.reasoning}`);
-
-  if (llmResult.proposal_id) {
-    // Verify the proposal_id actually exists
-    const matchedProposal = allProposals.find(p => p.id === llmResult.proposal_id);
-    if (!matchedProposal) {
-      console.log(
-        `    → WARNING: LLM returned non-existent proposal_id ${llmResult.proposal_id}, treating as no-match`,
-      );
-      llmResult.proposal_id = null;
-      llmResult.confidence = "none";
-      llmResult.confidence_score = 0;
-      llmResult.reasoning += " [proposal_id not found in database - auto-corrected to no-match]";
+  // Validate matched proposal IDs exist
+  const validMatches = llmResult.matches.filter(match => {
+    const exists = allProposals.find(p => p.id === match.proposal_id);
+    if (!exists) {
+      console.log(`    → WARNING: LLM returned non-existent proposal_id ${match.proposal_id}, skipping`);
     }
-  }
-
-  const isMatched = llmResult.proposal_id !== null;
-
-  // Update the stage's proposal_id if matched
-  if (isMatched && llmResult.proposal_id) {
-    if (sourceType === "tally") {
-      await updateTallyProposalId(stageId, llmResult.proposal_id);
-    } else {
-      await updateSnapshotProposalId(stageId, llmResult.proposal_id);
-    }
-  }
-
-  // Record the matching result
-  await upsertMatchingResult({
-    source_type: sourceType,
-    source_stage_id: stageId,
-    proposal_id: llmResult.proposal_id,
-    status: isMatched ? "matched" : "no_match",
-    method: "llm",
-    confidence: llmResult.confidence_score,
-    reasoning: llmResult.reasoning,
-    source_title: stage.title,
-    source_url: stage.url,
+    return !!exists;
   });
 
-  return { status: isMatched ? "matched" : "no_match", proposalId: llmResult.proposal_id };
+  if (validMatches.length === 0) {
+    console.log(`    → NO MATCH (${llmResult.reasoning})`);
+
+    // Record a single no-match result
+    await upsertMatchingResult({
+      source_type: sourceType,
+      source_stage_id: stageId,
+      proposal_id: null,
+      status: "no_match",
+      method: "llm",
+      confidence: 0,
+      reasoning: llmResult.reasoning || "No matching proposal found",
+      source_title: stage.title,
+      source_url: stage.url,
+    });
+
+    return { status: "no_match", proposalId: null, matchCount: 0 };
+  }
+
+  console.log(`    → MATCHED ${validMatches.length} proposal(s)`);
+
+  // Create a matching_result row for each match + update the FK to the first/highest-confidence match
+  const primaryMatch = validMatches.reduce((best, m) => (m.confidence_score > best.confidence_score ? m : best));
+
+  if (sourceType === "tally") {
+    await updateTallyProposalId(stageId, primaryMatch.proposal_id);
+  } else {
+    await updateSnapshotProposalId(stageId, primaryMatch.proposal_id);
+  }
+
+  for (const match of validMatches) {
+    console.log(`      • ${match.proposal_id} (score: ${match.confidence_score}) — ${match.reasoning}`);
+    await upsertMatchingResult({
+      source_type: sourceType,
+      source_stage_id: stageId,
+      proposal_id: match.proposal_id,
+      status: "matched",
+      method: "llm",
+      confidence: match.confidence_score,
+      reasoning: match.reasoning,
+      source_title: stage.title,
+      source_url: stage.url,
+      matched_forum_url: forumUrlByProposal.get(match.proposal_id) ?? null,
+    });
+  }
+
+  return { status: "matched", proposalId: primaryMatch.proposal_id, matchCount: validMatches.length };
 }

--- a/packages/nextjs/services/matching/llm-matching.ts
+++ b/packages/nextjs/services/matching/llm-matching.ts
@@ -1,7 +1,7 @@
 import { upsertMatchingResult } from "../database/repositories/matching";
 import { getAllProposals } from "../database/repositories/proposals";
-import { getSnapshotStageById, updateSnapshotProposalId } from "../database/repositories/snapshot";
-import { getTallyStageById, updateTallyProposalId } from "../database/repositories/tally";
+import { getSnapshotStageById } from "../database/repositories/snapshot";
+import { getTallyStageById } from "../database/repositories/tally";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { and, eq } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
@@ -203,14 +203,8 @@ export async function matchStage(
 
   console.log(`    → MATCHED ${validMatches.length} proposal(s)`);
 
-  // Create a matching_result row for each match + update the FK to the first/highest-confidence match
+  // Create a matching_result row for each match
   const primaryMatch = validMatches.reduce((best, m) => (m.confidence_score > best.confidence_score ? m : best));
-
-  if (sourceType === "tally") {
-    await updateTallyProposalId(stageId, primaryMatch.proposal_id);
-  } else {
-    await updateSnapshotProposalId(stageId, primaryMatch.proposal_id);
-  }
 
   for (const match of validMatches) {
     console.log(`      • ${match.proposal_id} (score: ${match.confidence_score}) — ${match.reasoning}`);

--- a/packages/nextjs/services/matching/llm-matching.ts
+++ b/packages/nextjs/services/matching/llm-matching.ts
@@ -3,7 +3,9 @@ import { getAllProposals } from "../database/repositories/proposals";
 import { getSnapshotStageById, updateSnapshotProposalId } from "../database/repositories/snapshot";
 import { getTallyStageById, updateTallyProposalId } from "../database/repositories/tally";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { and, eq } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
+import { matchingResult } from "~~/services/database/config/schema";
 
 interface LlmMatch {
   proposal_id: string;
@@ -173,6 +175,12 @@ export async function matchStage(
     }
     return !!exists;
   });
+
+  // Mark any previous results for this stage as overwritten
+  await db
+    .update(matchingResult)
+    .set({ status: "overwritten", updated_at: new Date() })
+    .where(and(eq(matchingResult.source_type, sourceType), eq(matchingResult.source_stage_id, stageId)));
 
   if (validMatches.length === 0) {
     console.log(`    → NO MATCH (${llmResult.reasoning})`);

--- a/packages/nextjs/services/snapshot/import.ts
+++ b/packages/nextjs/services/snapshot/import.ts
@@ -72,7 +72,6 @@ const transformProposalData = (proposal: SnapshotProposal) => {
       scores: proposal.scores,
     },
     updated_at: new Date(),
-    proposal_id: null,
   };
 };
 
@@ -134,9 +133,8 @@ const createNewSnapshotStage = async (proposal: SnapshotProposal) => {
 const updateExistingSnapshotStage = async (proposal: SnapshotProposal) => {
   const snapshotData = transformProposalData(proposal);
 
-  // Remove fields that shouldn't be updated
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { snapshot_id, proposal_id, ...updates } = snapshotData;
+  const { snapshot_id, ...updates } = snapshotData;
 
   const snapshotStage = await updateSnapshotStageBySnapshotId(proposal.id, updates);
   console.log("Updated snapshot stage:", snapshotStage.title);

--- a/packages/nextjs/services/tally/import.ts
+++ b/packages/nextjs/services/tally/import.ts
@@ -243,7 +243,6 @@ const transformProposalData = (proposal: TallyProposal) => {
         ? new Date(proposal.start.timestamp)
         : new Date(proposal.createdAt),
     updated_at: new Date(),
-    proposal_id: null,
   };
 };
 
@@ -349,9 +348,8 @@ const createNewTallyStage = async (proposal: TallyProposal) => {
 const updateExistingTallyStage = async (proposal: TallyProposal) => {
   const tallyData = transformProposalData(proposal);
 
-  // Remove fields that shouldn't be updated
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { tally_proposal_id, proposal_id, ...updates } = tallyData;
+  const { tally_proposal_id, ...updates } = tallyData;
 
   const tallyStage = await updateTallyStageByTallyProposalId(proposal.id, updates);
   console.log("Updated tally stage:", tallyStage.title);


### PR DESCRIPTION
The big change is to handle tally or snapshot stages that are attached to several proposals, sometimes they bundle a vote of several proposals like in this screenshot, now the source of truth is the matching_result table instead of the foreign keys of the snapshot and tally stages.

<img width="1421" height="202" alt="image" src="https://github.com/user-attachments/assets/32741929-aa4a-4d6c-a43f-85ca1986ce57" />

In this commit 595285bcf9b65cf24ccf5f15c983842e28bf8072 I add `overwritten` status instead of deleting the old matching, to keep the track of matching changes, in case something goes wrong and we want to go back to the old matching easily.

<img width="892" height="73" alt="image" src="https://github.com/user-attachments/assets/4deb723f-501f-4ba4-a995-9078b6b5424e" />

## Summary

Allows a single tally/snapshot stage to be linked to multiple proposals (e.g. bundled on-chain votes). Adds activity-based ordering to the admin matching dashboard and improves the LLM matching prompt to detect and return multiple proposal matches.

## Changes

1. **Last activity ordering** — Pending stages sorted by voting_end/last_activity instead of insertion date
2. **Multi-proposal schema** — matching_result unique constraint changed to (source_type, source_stage_id, proposal_id)
3. **Dashboard rewrite** — getDashboardProposals now sources stages from matching_result joins instead of FK relations
4. **LLM multi-match** — Prompt instructs Gemini to return an array of matches for bundled votes; creates one matching_result row per matched proposal
5. **Import fix** — Phase 2 of CSV import resolves stages by title instead of stale JSON UUIDs
6. **UI polish** — Improved link visibility in match details modal

## How to test

1. Run `yarn drizzle-kit push` to apply the schema change (adds proposal_id to the unique constraint)
2. Truncate matching_result and re-run `yarn import:all-csv`
3. Homepage: verify proposals display correctly with stage links
4. Admin matching: re-match a bundled tally vote (e.g. 'Remove Cost Cap, Update Executors, Disable Legacy USDT Bridge') and verify it returns multiple matches
5. Check that all matched proposals show the same tally stage on the homepage

## ⚠️ Things to watch

- **Database migration required**: The unique constraint on matching_result changes — run `yarn drizzle-kit push` before deploying
- **matching_result is now the source of truth** for stage-to-proposal links (proposal_id FK on stage tables is preserved for rollback)
- The import scripts now require `getAllTallyStages`/`getAllSnapshotStages` functions