### PR TITLE
SIWE verifier to use dynamic chainId for public client

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -11,7 +11,7 @@ export type BaseConfig = {
 
 export type ScaffoldConfig = BaseConfig;
 
-export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+export const DEFAULT_ALCHEMY_API_KEY = "cR4WnXePioePZ5fFrnSiR";
 
 const scaffoldConfig = {
   // The networks on which your DApp is live

--- a/packages/nextjs/utils/auth.ts
+++ b/packages/nextjs/utils/auth.ts
@@ -3,15 +3,31 @@ import { AuthOptions, Session, User, getServerSession } from "next-auth";
 import { JWT } from "next-auth/jwt";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { getCsrfToken } from "next-auth/react";
-import { createPublicClient, http } from "viem";
-import { mainnet } from "viem/chains";
+import { Chain, createPublicClient, fallback, http } from "viem";
 import { type SiweMessage, parseSiweMessage, validateSiweMessage } from "viem/siwe";
+import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY, ScaffoldConfig } from "~~/scaffold.config";
 import { isAddressAdmin } from "~~/services/database/repositories/users";
+import { enabledChains } from "~~/services/web3/wagmiConfig";
+import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
 
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(),
-});
+const getPublicClientForChain = (chainId: number) => {
+  const chain = (enabledChains as readonly Chain[]).find(c => c.id === chainId);
+  if (!chain) return null;
+
+  let rpcFallbacks = [http()];
+  const rpcOverrideUrl = (scaffoldConfig.rpcOverrides as ScaffoldConfig["rpcOverrides"])?.[chain.id];
+  if (rpcOverrideUrl) {
+    rpcFallbacks = [http(rpcOverrideUrl), http()];
+  } else {
+    const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
+    if (alchemyHttpUrl) {
+      const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
+      rpcFallbacks = isUsingDefaultKey ? [http(), http(alchemyHttpUrl)] : [http(alchemyHttpUrl), http()];
+    }
+  }
+
+  return createPublicClient({ chain, transport: fallback(rpcFallbacks) });
+};
 
 export const providers = [
   CredentialsProvider({
@@ -35,6 +51,12 @@ export const providers = [
         }
 
         const siweMessage = parseSiweMessage(credentials.message) as SiweMessage;
+
+        const publicClient = getPublicClientForChain(siweMessage.chainId);
+        if (!publicClient) {
+          console.error(`Authorization error: SIWE chainId ${siweMessage.chainId} is not in enabledChains`);
+          return null;
+        }
 
         const isMessageValid = validateSiweMessage({
           address: siweMessage?.address,


### PR DESCRIPTION
The verifier was instantiating a mainnet publicClient at module load, so SIWE authorization failed whenever the wallet signed on any other chain. Resolve the verifier dynamically against the SIWE message's chainId, gated by enabledChains so unknown chains are rejected. RPC fallback follows the SE-2 pattern: rpcOverride → Alchemy → public, with Alchemy deprioritised when the shared default key is in use.

Also bumps DEFAULT_ALCHEMY_API_KEY in scaffold.config.ts to keep the key-comparison branch in auth.ts aligned.