### PR TITLE
Refactor /admin/matching to use TanStack Query

### DIFF
--- a/packages/nextjs/app/admin/matching/_components/JobPoller.tsx
+++ b/packages/nextjs/app/admin/matching/_components/JobPoller.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { useJobStatus } from "../_hooks/useMatchingQueries";
+
+interface Props {
+  jobId: string;
+  stageId: string;
+  onComplete: (stageId: string) => void;
+  onError: (stageId: string, message: string) => void;
+}
+
+export function JobPoller({ jobId, stageId, onComplete, onError }: Props) {
+  const { data, isError } = useJobStatus(jobId);
+
+  useEffect(() => {
+    if (data?.status === "completed") {
+      onComplete(stageId);
+    } else if (data?.status === "error") {
+      onError(stageId, data.error ?? "Matching failed");
+    }
+  }, [data, stageId, onComplete, onError]);
+
+  useEffect(() => {
+    if (isError) {
+      onError(stageId, "Lost track of matching job. Please refresh the page.");
+    }
+  }, [isError, stageId, onError]);
+
+  return null;
+}

--- a/packages/nextjs/app/admin/matching/_components/MatchingDashboard.tsx
+++ b/packages/nextjs/app/admin/matching/_components/MatchingDashboard.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import {
+  useExecuteMatch,
+  useInvalidateMatchingLists,
+  useMatchingPending,
+  useMatchingResults,
+} from "../_hooks/useMatchingQueries";
+import { JobPoller } from "./JobPoller";
 import { MatchingResultsTable } from "./MatchingResultsTable";
 import { PendingStagesTable } from "./PendingStagesTable";
-import { MatchingResultRow, PendingStage } from "./types";
+import { SourceType } from "./types";
+
+const PENDING_PLACEHOLDER = "pending";
 
 export function MatchingDashboard() {
-  const [pending, setPending] = useState<PendingStage[]>([]);
-  const [results, setResults] = useState<MatchingResultRow[]>([]);
+  const pendingQuery = useMatchingPending();
+  const resultsQuery = useMatchingResults();
+  const executeMutation = useExecuteMatch();
+  const invalidateLists = useInvalidateMatchingLists();
+
   const [runningJobs, setRunningJobs] = useState<Map<string, string>>(new Map());
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const removeRunningJob = useCallback((stageId: string) => {
@@ -20,96 +31,43 @@ export function MatchingDashboard() {
     });
   }, []);
 
-  const fetchData = useCallback(async () => {
-    try {
-      const [pendingRes, resultsRes] = await Promise.all([
-        fetch("/api/admin/matching/pending"),
-        fetch("/api/admin/matching/results"),
-      ]);
-
-      if (pendingRes.ok) setPending(await pendingRes.json());
-      if (resultsRes.ok) setResults(await resultsRes.json());
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to fetch data");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  const pollJob = useCallback(
-    async (jobId: string, stageId: string) => {
-      let retries = 0;
-      const poll = async () => {
-        try {
-          const res = await fetch(`/api/admin/matching/status/${jobId}`);
-          if (!res.ok) {
-            retries++;
-            if (retries >= 3) {
-              // After 3 failed polls, give up and clean up loading state
-              removeRunningJob(stageId);
-              setError("Lost track of matching job. Please refresh the page.");
-              return;
-            }
-            setTimeout(poll, 2000);
-            return;
-          }
-          retries = 0;
-          const job = await res.json();
-
-          if (job.status === "completed" || job.status === "error") {
-            removeRunningJob(stageId);
-            await fetchData();
-            return;
-          }
-
-          // Still running, poll again
-          setTimeout(poll, 2000);
-        } catch {
-          // On error, stop polling
-          removeRunningJob(stageId);
-        }
-      };
-      setTimeout(poll, 2000);
+  const handleJobComplete = useCallback(
+    (stageId: string) => {
+      removeRunningJob(stageId);
+      invalidateLists();
     },
-    [fetchData, removeRunningJob],
+    [removeRunningJob, invalidateLists],
+  );
+
+  const handleJobError = useCallback(
+    (stageId: string, message: string) => {
+      removeRunningJob(stageId);
+      setError(message);
+    },
+    [removeRunningJob],
   );
 
   const executeMatch = useCallback(
-    async (sourceType: "snapshot" | "tally", stageId: string) => {
-      // Show loading immediately before the API call
-      setRunningJobs(prev => new Map(prev).set(stageId, "pending"));
+    (sourceType: SourceType, stageId: string) => {
+      setRunningJobs(prev => new Map(prev).set(stageId, PENDING_PLACEHOLDER));
 
-      try {
-        const res = await fetch("/api/admin/matching/execute", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sourceType, stageId }),
-        });
-
-        if (!res.ok) {
-          const data = await res.json();
-          setError(data.error || "Failed to start matching");
-          removeRunningJob(stageId);
-          return;
-        }
-
-        const { jobId } = await res.json();
-        setRunningJobs(prev => new Map(prev).set(stageId, jobId));
-        pollJob(jobId, stageId);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to start matching");
-        removeRunningJob(stageId);
-      }
+      executeMutation.mutate(
+        { sourceType, stageId },
+        {
+          onSuccess: ({ jobId }) => {
+            setRunningJobs(prev => new Map(prev).set(stageId, jobId));
+          },
+          onError: err => {
+            removeRunningJob(stageId);
+            setError(err instanceof Error ? err.message : "Failed to start matching");
+          },
+        },
+      );
     },
-    [pollJob, removeRunningJob],
+    [executeMutation, removeRunningJob],
   );
 
-  if (loading) {
+  if (pendingQuery.isLoading || resultsQuery.isLoading) {
     return (
       <div className="flex justify-center py-12">
         <span className="loading loading-spinner loading-lg" />
@@ -117,11 +75,26 @@ export function MatchingDashboard() {
     );
   }
 
+  const fetchError = pendingQuery.error?.message ?? resultsQuery.error?.message ?? null;
+  const displayError = error ?? fetchError;
+
   return (
     <div className="flex flex-col gap-4">
-      {error && (
+      {Array.from(runningJobs.entries()).map(([stageId, jobId]) =>
+        jobId !== PENDING_PLACEHOLDER ? (
+          <JobPoller
+            key={jobId}
+            jobId={jobId}
+            stageId={stageId}
+            onComplete={handleJobComplete}
+            onError={handleJobError}
+          />
+        ) : null,
+      )}
+
+      {displayError && (
         <div className="alert alert-error">
-          <span>{error}</span>
+          <span>{displayError}</span>
           <button className="btn btn-ghost btn-xs" onClick={() => setError(null)}>
             Dismiss
           </button>
@@ -130,12 +103,12 @@ export function MatchingDashboard() {
 
       <section>
         <h2 className="text-2xl font-semibold mb-2">Pending Stages</h2>
-        <PendingStagesTable stages={pending} runningJobs={runningJobs} onMatch={executeMatch} />
+        <PendingStagesTable stages={pendingQuery.data ?? []} runningJobs={runningJobs} onMatch={executeMatch} />
       </section>
 
       <section>
         <h2 className="text-2xl font-semibold mb-2">Matching Results</h2>
-        <MatchingResultsTable results={results} runningJobs={runningJobs} onRematch={executeMatch} />
+        <MatchingResultsTable results={resultsQuery.data ?? []} runningJobs={runningJobs} onRematch={executeMatch} />
       </section>
     </div>
   );

--- a/packages/nextjs/app/admin/matching/_hooks/useMatchingQueries.ts
+++ b/packages/nextjs/app/admin/matching/_hooks/useMatchingQueries.ts
@@ -1,0 +1,95 @@
+import type { MatchingResultRow, PendingStage, SourceType } from "../_components/types";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export interface MatchJobStatus {
+  id: string;
+  status: "running" | "completed" | "error";
+  result?: { status: string; proposalId: string | null };
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+export const matchingKeys = {
+  all: ["admin", "matching"] as const,
+  pending: () => [...matchingKeys.all, "pending"] as const,
+  results: () => [...matchingKeys.all, "results"] as const,
+  jobStatus: (jobId: string) => [...matchingKeys.all, "status", jobId] as const,
+};
+
+const STALE_TIME = 30_000;
+const POLL_INTERVAL_MS = 2000;
+
+export function useMatchingPending() {
+  return useQuery({
+    queryKey: matchingKeys.pending(),
+    queryFn: async (): Promise<PendingStage[]> => {
+      const res = await fetch("/api/admin/matching/pending");
+      if (!res.ok) throw new Error("Failed to fetch pending stages");
+      return res.json();
+    },
+    staleTime: STALE_TIME,
+  });
+}
+
+export function useMatchingResults() {
+  return useQuery({
+    queryKey: matchingKeys.results(),
+    queryFn: async (): Promise<MatchingResultRow[]> => {
+      const res = await fetch("/api/admin/matching/results");
+      if (!res.ok) throw new Error("Failed to fetch matching results");
+      return res.json();
+    },
+    staleTime: STALE_TIME,
+  });
+}
+
+export function useExecuteMatch() {
+  return useMutation({
+    mutationFn: async ({
+      sourceType,
+      stageId,
+    }: {
+      sourceType: SourceType;
+      stageId: string;
+    }): Promise<{ jobId: string }> => {
+      const res = await fetch("/api/admin/matching/execute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceType, stageId }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to start matching");
+      }
+      return res.json();
+    },
+  });
+}
+
+export function useJobStatus(jobId: string | null) {
+  return useQuery({
+    queryKey: jobId ? matchingKeys.jobStatus(jobId) : [...matchingKeys.all, "status", "noop"],
+    queryFn: async (): Promise<MatchJobStatus> => {
+      const res = await fetch(`/api/admin/matching/status/${jobId}`);
+      if (!res.ok) throw new Error("Status check failed");
+      return res.json();
+    },
+    enabled: !!jobId,
+    refetchInterval: query => {
+      const data = query.state.data;
+      if (data?.status === "completed" || data?.status === "error") return false;
+      return POLL_INTERVAL_MS;
+    },
+    retry: 3,
+    retryDelay: POLL_INTERVAL_MS,
+  });
+}
+
+export function useInvalidateMatchingLists() {
+  const queryClient = useQueryClient();
+  return () => {
+    queryClient.invalidateQueries({ queryKey: matchingKeys.pending() });
+    queryClient.invalidateQueries({ queryKey: matchingKeys.results() });
+  };
+}


### PR DESCRIPTION
## Summary
Replaces the hand-rolled `useEffect` + `fetch` and recursive `setTimeout` polling in `/admin/matching` with `useQuery` / `useMutation` from `@tanstack/react-query` — which is already wired up via the app's `QueryClientProvider`.

This was the only client-side fetch pattern in the app; everything else is either a Server Component or `wagmi` (which uses TanStack Query internally).

## What changed
- `_hooks/useMatchingQueries.ts` — `useMatchingPending`, `useMatchingResults`, `useExecuteMatch`, `useJobStatus`, with a shared `queryKey` factory.
- `_components/JobPoller.tsx` — renders nothing, polls one job via `refetchInterval`, calls back to the parent on completion/error.
- `MatchingDashboard.tsx` composes the hooks instead of orchestrating fetches by hand. `runningJobs` stays as local state since it's transient UI state, not server state.

## Test plan
- [ ] `/admin/matching` loads pending + results.
- [ ] Click **Match** — button spins, `<JobPoller>` polls every 2s, lists refresh on completion.
- [ ] `/admin/matching` → `/` → back within 30s — instant render from cache (no spinner).