### PR TITLE
feat: daily Vercel Cron for LLM matching of pending stages

### DIFF
--- a/packages/nextjs/app/api/match-pending-stages/route.ts
+++ b/packages/nextjs/app/api/match-pending-stages/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUnprocessedSnapshotStages, getUnprocessedTallyStages } from "~~/services/database/repositories/matching";
+import { matchStage } from "~~/services/matching/llm-matching";
+
+export const maxDuration = 300;
+
+interface StageRunResult {
+  sourceType: "snapshot" | "tally";
+  stageId: string;
+  status: "matched" | "no_match" | "not_found" | "error";
+  matchCount?: number;
+  error?: string;
+}
+
+export async function GET(request: NextRequest) {
+  const startedAt = Date.now();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    console.error("Unauthorized attempt to access match-pending-stages endpoint");
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Stop processing once we're within this many ms of maxDuration to leave
+  // headroom for the response. Any stages not reached this run will remain
+  // unprocessed and get picked up by the next cron run.
+  const SAFETY_MARGIN_MS = 30_000;
+  const deadline = startedAt + maxDuration * 1000 - SAFETY_MARGIN_MS;
+
+  const results: StageRunResult[] = [];
+  let processed = 0;
+  let skipped = 0;
+
+  try {
+    const [snapshotRows, tallyRows] = await Promise.all([getUnprocessedSnapshotStages(), getUnprocessedTallyStages()]);
+
+    const queue: { sourceType: "snapshot" | "tally"; stageId: string }[] = [
+      ...snapshotRows.map(r => ({ sourceType: "snapshot" as const, stageId: r.snapshotStage.id })),
+      ...tallyRows.map(r => ({ sourceType: "tally" as const, stageId: r.tallyStage.id })),
+    ];
+
+    console.log(
+      `match-pending-stages: ${queue.length} stage(s) pending (${snapshotRows.length} snapshot, ${tallyRows.length} tally)`,
+    );
+
+    for (const { sourceType, stageId } of queue) {
+      if (Date.now() > deadline) {
+        skipped = queue.length - processed;
+        console.log(`match-pending-stages: deadline reached, skipping ${skipped} remaining stage(s) for next run`);
+        break;
+      }
+
+      try {
+        const result = await matchStage(sourceType, stageId);
+        results.push({
+          sourceType,
+          stageId,
+          status: result.status as StageRunResult["status"],
+          matchCount: result.matchCount,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`match-pending-stages: error matching ${sourceType}/${stageId}:`, message);
+        results.push({ sourceType, stageId, status: "error", error: message });
+      }
+
+      processed++;
+    }
+
+    const durationMs = Date.now() - startedAt;
+    const matched = results.filter(r => r.status === "matched").length;
+    const noMatch = results.filter(r => r.status === "no_match").length;
+    const errors = results.filter(r => r.status === "error").length;
+
+    console.log(
+      `match-pending-stages: finished in ${durationMs}ms — processed=${processed}, matched=${matched}, no_match=${noMatch}, errors=${errors}, skipped=${skipped}`,
+    );
+
+    return NextResponse.json({
+      success: true,
+      durationMs,
+      processed,
+      matched,
+      noMatch,
+      errors,
+      skipped,
+      results,
+    });
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    console.error(`match-pending-stages: fatal error after ${durationMs}ms:`, error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error occurred",
+        durationMs,
+        processed,
+        results,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/nextjs/app/api/match-pending-stages/route.ts
+++ b/packages/nextjs/app/api/match-pending-stages/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUnprocessedSnapshotStages, getUnprocessedTallyStages } from "~~/services/database/repositories/matching";
-import { matchStage } from "~~/services/matching/llm-matching";
+import { MatchStageStatus, matchStage } from "~~/services/matching/llm-matching";
 
 export const maxDuration = 300;
 
 interface StageRunResult {
   sourceType: "snapshot" | "tally";
   stageId: string;
-  status: "matched" | "no_match" | "not_found" | "error";
+  status: MatchStageStatus | "error";
   matchCount?: number;
   error?: string;
 }
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
         results.push({
           sourceType,
           stageId,
-          status: result.status as StageRunResult["status"],
+          status: result.status,
           matchCount: result.matchCount,
         });
       } catch (err) {
@@ -74,19 +74,22 @@ export async function GET(request: NextRequest) {
     const errors = results.filter(r => r.status === "error").length;
 
     console.log(
-      `match-pending-stages: finished in ${durationMs}ms — processed=${processed}, matched=${matched}, no_match=${noMatch}, errors=${errors}, skipped=${skipped}`,
+      `match-pending-stages: finished in ${durationMs}ms - processed=${processed}, matched=${matched}, no_match=${noMatch}, errors=${errors}, skipped=${skipped}`,
     );
 
-    return NextResponse.json({
-      success: true,
-      durationMs,
-      processed,
-      matched,
-      noMatch,
-      errors,
-      skipped,
-      results,
-    });
+    return NextResponse.json(
+      {
+        success: errors === 0,
+        durationMs,
+        processed,
+        matched,
+        noMatch,
+        errors,
+        skipped,
+        results,
+      },
+      { status: errors > 0 ? 500 : 200 },
+    );
   } catch (error) {
     const durationMs = Date.now() - startedAt;
     console.error(`match-pending-stages: fatal error after ${durationMs}ms:`, error);

--- a/packages/nextjs/services/matching/llm-matching.ts
+++ b/packages/nextjs/services/matching/llm-matching.ts
@@ -129,10 +129,15 @@ async function callGemini(prompt: string): Promise<LlmMatchResult> {
   return parsed;
 }
 
-export async function matchStage(
-  sourceType: "tally" | "snapshot",
-  stageId: string,
-): Promise<{ status: string; proposalId: string | null; matchCount: number }> {
+export type MatchStageStatus = "matched" | "no_match" | "not_found";
+
+export interface MatchStageResult {
+  status: MatchStageStatus;
+  proposalId: string | null;
+  matchCount: number;
+}
+
+export async function matchStage(sourceType: "tally" | "snapshot", stageId: string): Promise<MatchStageResult> {
   // Load the stage info
   let stage: StageInfo | undefined;
 

--- a/packages/nextjs/vercel.json
+++ b/packages/nextjs/vercel.json
@@ -3,6 +3,7 @@
   "crons": [
     { "path": "/api/import-forum-posts", "schedule": "0 6 * * *" },
     { "path": "/api/import-snapshot-proposals", "schedule": "15 6 * * *" },
-    { "path": "/api/import-tally-proposals", "schedule": "30 6 * * *" }
+    { "path": "/api/import-tally-proposals", "schedule": "30 6 * * *" },
+    { "path": "/api/match-pending-stages", "schedule": "0 7 * * *" }
   ]
 }


### PR DESCRIPTION
After this PR is merged, I can update #33 to on-demand revalidation after this LLM matching cron

## Summary

Adds a daily Vercel Cron at 07:00 UTC that runs LLM matching against any unprocessed Snapshot/Tally stages, so newly-imported stages get linked to canonical forum proposals automatically instead of waiting for someone to click through `/admin/matching`.

- New endpoint `GET /api/match-pending-stages` (auth: `Bearer ${CRON_SECRET}`)
- Loops pending stages and `await`s `matchStage()` synchronously per stage — no in-memory job tracker, no cross-lambda polling, so the "lost track of job" issue from the manual UI doesn't apply
- Per-stage `try/catch`: a single failure doesn't abort the rest; failed/skipped stages stay pending and get retried on the next run
- 270s deadline (30s margin under `maxDuration = 300`); anything beyond rolls to the next day
- Returns HTTP 500 + `success: false` when any stage errors, so Vercel cron monitoring will surface failures
- `matchStage()` return type tightened to a `MatchStageStatus` literal union and exported, so the route consumes it without an `as` cast

Cron entry runs after the three existing import crons (06:00 / 06:15 / 06:30 UTC).

## How to test

Set `CRON_SECRET` and `GEMINI_API_KEY` locally, then:

```bash
# 401 without auth
curl -i "http://localhost:3000/api/match-pending-stages"

# 401 with wrong token
curl -i "http://localhost:3000/api/match-pending-stages" -H "Authorization: Bearer wrong"

# 200 with valid auth — empty queue returns processed=0 in <100ms
curl -i "http://localhost:3000/api/match-pending-stages" -H "Authorization: Bearer $CRON_SECRET"
```

To exercise the matching path, delete a few rows from `matching_result` for known stage IDs (so they reappear in the unprocessed queries) and re-run the authorized curl. The response should report `processed`, `matched`, `noMatch`, `errors`, and a `results[]` with per-stage outcomes.

After deploy, confirm the new entry appears in **Vercel Dashboard → Settings → Cron Jobs** alongside the three import crons. You can also click **Run** there to trigger it on demand without waiting for 07:00 UTC.

## Things to look out for

- **Auth**: same `Bearer ${CRON_SECRET}` pattern as the existing import routes. No session/SIWE involved (cron has no session).
- **Matching quality depends on `GEMINI_MODEL`**: matching results are only as good as the model in `services/matching/llm-matching.ts:83`. Make sure prod is configured with the model you want the cron writing to the DB every day.
- **No confidence-threshold gate**: pre-existing TODO at `llm-matching.ts:206-211` — every validated match goes straight to the homepage regardless of score. Worth a follow-up, not part of this PR.
- **Concurrent overlap with `/admin/matching`**: theoretically possible but very narrow window (24h between cron runs, ~12s LLM call per stage). Worst case is a wasted Gemini call and last-writer-wins on the result row; not data corruption.

<details>
<summary>Detailed change list</summary>

- `packages/nextjs/app/api/match-pending-stages/route.ts` (new): cron endpoint
- `packages/nextjs/services/matching/llm-matching.ts`: export `MatchStageStatus` / `MatchStageResult`, tighten `matchStage()` return type
- `packages/nextjs/vercel.json`: add cron entry at `0 7 * * *`

</details>